### PR TITLE
1.6.1 - Remove Hard Dependency on ai-dock base images

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Download the latest version from the release page, and copy it into your existin
 
 ```dockerfile
 # Change this to the version you want to use
-ARG api_version=1.6.0
+ARG api_version=1.6.1
 
 # Download the comfyui-api binary, and make it executable
 ADD https://github.com/SaladTechnologies/comfyui-api/releases/download/${api_version}/comfyui-api .
@@ -70,21 +70,22 @@ This guide provides an overview of how to configure the application using enviro
 The following table lists the available environment variables and their default values.
 The default values mostly assume this will run on top of an [ai-dock](https://github.com/ai-dock/comfyui) image, but can be customized as needed.
 
-| Variable                 | Default Value         | Description                                |
-| ------------------------ | --------------------- | ------------------------------------------ |
-| CMD                      | "init.sh"             | Command to launch ComfyUI                  |
-| HOST                     | "::"                  | Wrapper host address                       |
-| PORT                     | "3000"                | Wrapper port number                        |
-| DIRECT_ADDRESS           | "127.0.0.1"           | Direct address for ComfyUI                 |
-| COMFYUI_PORT_HOST        | "8188"                | ComfyUI port number                        |
-| STARTUP_CHECK_INTERVAL_S | "1"                   | Interval in seconds between startup checks |
-| STARTUP_CHECK_MAX_TRIES  | "10"                  | Maximum number of startup check attempts   |
-| COMFY_HOME               | "/opt/ComfyUI"        | ComfyUI home directory                     |
-| OUTPUT_DIR               | "/opt/ComfyUI/output" | Directory for output files                 |
-| INPUT_DIR                | "/opt/ComfyUI/input"  | Directory for input files                  |
-| MODEL_DIR                | "/opt/ComfyUI/models" | Directory for model files                  |
-| WARMUP_PROMPT_FILE       | (not set)             | Path to warmup prompt file (optional)      |
-| WORKFLOW_DIR             | "/workflows"          | Directory for workflow files               |
+| Variable                 | Default Value         | Description                                                                                                                                                                                            |
+| ------------------------ | --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| CMD                      | "init.sh"             | Command to launch ComfyUI                                                                                                                                                                              |
+| HOST                     | "::"                  | Wrapper host address                                                                                                                                                                                   |
+| PORT                     | "3000"                | Wrapper port number                                                                                                                                                                                    |
+| DIRECT_ADDRESS           | "127.0.0.1"           | Direct address for ComfyUI                                                                                                                                                                             |
+| COMFYUI_PORT_HOST        | "8188"                | ComfyUI port number                                                                                                                                                                                    |
+| STARTUP_CHECK_INTERVAL_S | "1"                   | Interval in seconds between startup checks                                                                                                                                                             |
+| STARTUP_CHECK_MAX_TRIES  | "10"                  | Maximum number of startup check attempts                                                                                                                                                               |
+| COMFY_HOME               | "/opt/ComfyUI"        | ComfyUI home directory                                                                                                                                                                                 |
+| OUTPUT_DIR               | "/opt/ComfyUI/output" | Directory for output files                                                                                                                                                                             |
+| INPUT_DIR                | "/opt/ComfyUI/input"  | Directory for input files                                                                                                                                                                              |
+| MODEL_DIR                | "/opt/ComfyUI/models" | Directory for model files                                                                                                                                                                              |
+| WARMUP_PROMPT_FILE       | (not set)             | Path to warmup prompt file (optional)                                                                                                                                                                  |
+| WORKFLOW_DIR             | "/workflows"          | Directory for workflow files                                                                                                                                                                           |
+| BASE                     | "ai-dock"             | There are different ways to load the comfyui environment for determining config values that vary with the base image. Currently only "ai-dock" has preset values. Set to empty string to not use this. |
 
 ### Configuration Details
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   comfyui:
-    image: saladtechnologies/comfyui:comfy0.2.2-api1.4.1-base
+    image: saladtechnologies/comfyui:comfy0.2.7-api1.6.0-base
     volumes:
       - ./bin:/app/bin
     command: ["/app/bin/comfyui-api"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-api",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-api",
-      "version": "1.6.0",
+      "version": "1.6.1",
       "license": "MIT",
       "dependencies": {
         "@fastify/swagger": "^8.15.0",
@@ -1164,9 +1164,9 @@
       "dev": true
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-api",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Wraps comfyui to make it easier to use as a stateless web service",
   "main": "dist/src/index.js",
   "scripts": {

--- a/src/config.ts
+++ b/src/config.ts
@@ -19,6 +19,7 @@ const {
   WORKFLOW_MODELS = "all",
   WORKFLOW_DIR = "/workflows",
   MARKDOWN_SCHEMA_DESCRIPTIONS = "true",
+  BASE = "ai-dock",
 } = process.env;
 
 fs.mkdirSync(WORKFLOW_DIR, { recursive: true });
@@ -28,6 +29,14 @@ const selfURL = `http://localhost:${PORT}`;
 const port = parseInt(PORT, 10);
 const startupCheckInterval = parseInt(STARTUP_CHECK_INTERVAL_S, 10) * 1000;
 const startupCheckMaxTries = parseInt(STARTUP_CHECK_MAX_TRIES, 10);
+
+// type for {string: string}
+
+const loadEnvCommand: Record<string, string> = {
+  "ai-dock": `source /opt/ai-dock/etc/environment.sh \
+  && source /opt/ai-dock/bin/venv-set.sh comfyui \
+  && source "$COMFYUI_VENV/bin/activate"`,
+};
 
 // The parent directory of model_dir
 const comfyDir = COMFY_HOME;
@@ -73,11 +82,11 @@ with open("${temptComfyFilePath}", "w") as f:
 `;
 
   const tempFilePath = path.join(comfyDir, "temp_comfy_description.py");
-  const command = `
-  source /opt/ai-dock/etc/environment.sh \
-  && source /opt/ai-dock/bin/venv-set.sh comfyui \
-  && source "$COMFYUI_VENV/bin/activate" \
-  && python ${tempFilePath}`;
+  let command = `python ${tempFilePath}`;
+  if (BASE in loadEnvCommand) {
+    command = `${loadEnvCommand[BASE]} \
+    && python ${tempFilePath}`;
+  }
 
   try {
     // Write the Python code to a temporary file

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -17,7 +17,10 @@ export async function sleep(ms: number): Promise<void> {
 }
 
 export function launchComfyUI() {
-  commandExecutor.execute(config.comfyLaunchCmd, [], {
+  const cmdAndArgs = config.comfyLaunchCmd.split(" ");
+  const cmd = cmdAndArgs[0];
+  const args = cmdAndArgs.slice(1);
+  commandExecutor.execute(cmd, args, {
     DIRECT_ADDRESS: config.comfyHost,
     COMFYUI_PORT_HOST: config.comfyPort,
     WEB_ENABLE_AUTH: "false",


### PR DESCRIPTION
There was a bit of code that was specific to loading the environment on an ai-dock image. this has been changed so that it can be disabled, allowing for different base images.