### PR TITLE
Avoid pip cache to shrink image size

### DIFF
--- a/docker/comfyui-cuda12.8.dockerfile
+++ b/docker/comfyui-cuda12.8.dockerfile
@@ -16,15 +16,15 @@ RUN python3 -m venv /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
 RUN . /opt/venv/bin/activate
 
-RUN pip install --upgrade pip
-RUN pip install --pre torch torchvision torchaudio \
+RUN pip install --no-cache-dir --upgrade pip
+RUN pip install --no-cache-dir --pre torch torchvision torchaudio \
     --index-url https://download.pytorch.org/whl/nightly/cu128
-RUN pip install comfy-cli
+RUN pip install --no-cache-dir comfy-cli
 WORKDIR /opt
 ARG comfy_version=0.3.29
 RUN git clone --depth 1 --branch v${comfy_version} https://github.com/comfyanonymous/ComfyUI.git
 WORKDIR /opt/ComfyUI
-RUN pip install -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
 ENV COMFY_HOME=/opt/ComfyUI
 RUN comfy --skip-prompt tracking disable
 RUN comfy --skip-prompt set-default ${COMFY_HOME}

--- a/docker/comfyui.dockerfile
+++ b/docker/comfyui.dockerfile
@@ -12,14 +12,14 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y \
   && rm -rf /var/lib/apt/lists/*
 
 # Install comfy-cli, which makes it easy to install custom nodes and other comfy specific functionality.
-RUN pip install --upgrade pip
-RUN pip install comfy-cli
+RUN pip install --no-cache-dir --upgrade pip
+RUN pip install --no-cache-dir comfy-cli
 WORKDIR /opt
 ARG comfy_version=0.3.29
 RUN git clone --depth 1 --branch v${comfy_version} https://github.com/comfyanonymous/ComfyUI.git
 WORKDIR /opt/ComfyUI
-RUN pip install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cu124
-RUN pip install -r requirements.txt
+RUN pip install --no-cache-dir torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cu124
+RUN pip install --no-cache-dir -r requirements.txt
 ENV COMFY_HOME=/opt/ComfyUI
 RUN comfy --skip-prompt tracking disable
 RUN comfy --skip-prompt set-default ${COMFY_HOME}


### PR DESCRIPTION
adding `--no-cache-dir` to `pip install` calls in `Dockerfiles` to avoid accumulating cache and keep images lean. (Saves a couple GB)