### PR TITLE
fix download image

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -37,10 +37,10 @@ export async function downloadImage(
     const fileStream = fs.createWriteStream(outputPath);
 
     // Pipe the response to the file
-    await new Promise((resolve, reject) => {
+    await new Promise<void>((resolve, reject) => {
       Readable.fromWeb(body as any)
         .pipe(fileStream)
-        .on("finish", () => resolve)
+        .on("finish", () => resolve())
         .on("error", reject);
     });
 


### PR DESCRIPTION
**Issue:** downloadImage will cause the program to freeze
**Reason:** Incorrect usage of resolve
This PR fixes the Promise resolution in the stream piping handler by properly invoking the resolve() function.

Both approaches work correctly:
- `() => resolve()`
- `resolve`