### PR TITLE
fix: s3 upload fails when using convert_output

### DIFF
--- a/src/storage-providers/s3.ts
+++ b/src/storage-providers/s3.ts
@@ -238,7 +238,7 @@ export class S3Upload implements Upload {
     if (typeof fileOrPath === "string") {
       return fs.createReadStream(fileOrPath);
     } else {
-      return fileOrPath;
+      return Buffer.from(fileOrPath);
     }
   }
 


### PR DESCRIPTION
fix #121 

This PR fixes the TypeError encountered when uploading converted images (convert_output) to S3. The issue was caused by the image processing outputting a SharedArrayBuffer, which is not directly supported by the S3 uploader.

This fix has been running in my own production environment for a considerable amount of time and has proven to be stable.