### PR TITLE
feat: add MiniMax as alternative LLM provider for generate-workflow

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -293,16 +293,24 @@ Would yield the following endpoints:
 These endpoints will be present in the swagger docs, and can be used to interact with the API.
 If you provide descriptions in your zod schemas, these will be used to create a markdown table of inputs in the swagger docs.
 
-### Automating with Claude 4 Sonnet
+### Automating with an LLM
 
-> **Note**: This requires having an account with Anthropic, and your anthropic API key in the environment variable `ANTHROPIC_API_KEY`.
-
-Creating these endpoints can be done mostly automatically by [Claude 4 Sonnet](https://console.anthropic.com/), given the JSON prompt graph.
+Creating these endpoints can be done mostly automatically by a large language model, given the JSON prompt graph.
 A [system prompt](./claude-endpoint-creation-prompt.md) to do this is included in this repository, as is [a script that uses this prompt](./generate-workflow) to create endpoints. It requires `jq` and `curl` to be installed.
 
 ```shell
 ./generate-workflow <inputFile> <outputFile>
 ```
+
+The script supports two LLM providers and picks one based on your environment:
+
+| Provider | Environment variable | Model used |
+|---|---|---|
+| Anthropic (default) | `ANTHROPIC_API_KEY` | `claude-sonnet-4-20250514` |
+| [MiniMax](https://www.minimax.io/) | `MINIMAX_API_KEY` | `MiniMax-M2.7` (204 K context) |
+
+When both variables are set, Anthropic is preferred.
+MiniMax uses the OpenAI-compatible endpoint (`https://api.minimax.io/v1`) so no extra dependencies are needed.
 
 Where `<inputFile>` is the JSON prompt graph, and `<outputFile>` is the output file to write the generated workflow to.
 

--- a/generate-workflow
+++ b/generate-workflow
@@ -5,21 +5,59 @@ usage="Usage: $0 <input-prompt-json> <output-typescript-file>"
 input_prompt_json=$1
 output_typescript_file=$2
 
-api_url=https://api.anthropic.com/v1/messages
-api_key=$ANTHROPIC_API_KEY
-if [ -z "$api_key" ]; then
-  echo "Please set the ANTHROPIC_API_KEY environment variable"
-  exit 1
-fi
-model_id=claude-sonnet-4-20250514
-anthropic_version=2023-06-01
-
 set -f # Disable globbing, there's a * in the input prompt
 system_prompt=$(jq -R -s '{"text": .}' claude-endpoint-creation-prompt.md | jq .text)
 input_prompt=$(jq @json $input_prompt_json)
 
-api_body=$(
-  cat <<EOF
+# Select LLM provider based on available API keys.
+# Anthropic (Claude) is preferred when both keys are set.
+# MiniMax is used as a fallback via its OpenAI-compatible API.
+if [ -n "$ANTHROPIC_API_KEY" ]; then
+  provider="anthropic"
+  api_key="$ANTHROPIC_API_KEY"
+  api_url="https://api.anthropic.com/v1/messages"
+  model_id="claude-sonnet-4-20250514"
+  anthropic_version="2023-06-01"
+elif [ -n "$MINIMAX_API_KEY" ]; then
+  provider="minimax"
+  api_key="$MINIMAX_API_KEY"
+  api_url="https://api.minimax.io/v1/chat/completions"
+  model_id="MiniMax-M2.7"
+else
+  echo "Please set the ANTHROPIC_API_KEY or MINIMAX_API_KEY environment variable" >&2
+  exit 1
+fi
+
+if [ "$provider" = "minimax" ]; then
+  # MiniMax uses the OpenAI-compatible API format.
+  # temperature must be in (0.0, 1.0] for MiniMax; 0.01 gives near-deterministic output.
+  api_body=$(
+    cat <<EOF
+{
+  "model": "$model_id",
+  "messages": [
+    {"role": "system", "content": $system_prompt},
+    {"role": "user", "content": $input_prompt}
+  ],
+  "max_tokens": 8192,
+  "temperature": 0.01
+}
+EOF
+  )
+
+  response=$(
+    curl -s -X POST \
+      -H "Authorization: Bearer $api_key" \
+      -H "Content-Type: application/json" \
+      -d "$api_body" \
+      "$api_url"
+  )
+
+  response_text=$(echo "$response" | jq -r '.choices[0].message.content // empty')
+else
+  # Anthropic API format
+  api_body=$(
+    cat <<EOF
 {
   "model": "$model_id",
   "system": $system_prompt,
@@ -33,26 +71,32 @@ api_body=$(
   ]
 }
 EOF
-)
+  )
 
-response=$(
-  curl -s -X POST \
-    -H "x-api-key: $api_key" \
-    -H "Content-Type: application/json" \
-    -H "anthropic-version: $anthropic_version" \
-    -d "$api_body" \
-    $api_url
-)
+  response=$(
+    curl -s -X POST \
+      -H "x-api-key: $api_key" \
+      -H "Content-Type: application/json" \
+      -H "anthropic-version: $anthropic_version" \
+      -d "$api_body" \
+      "$api_url"
+  )
 
-if [ -z "$(echo $response | jq -r .content[0].text)" ]; then
+  response_text=$(echo "$response" | jq -r '.content[0].text // empty')
+fi
+
+if [ -z "$response_text" ]; then
   echo "Error: API call failed" >&2
-  echo $response | jq . >&2
+  echo "$response" | jq . >&2
   exit 1
 fi
 
-response_text=$(echo $response | jq -r .content[0].text)
-
-# Drop the first and last lines, which are the ```typescript delimiters
-echo "$response_text" | tail -n +2 | head -n -1 > $output_typescript_file
+# Strip code-block delimiters if the model wrapped the output in ``` fences.
+first_line=$(echo "$response_text" | head -n 1)
+if [[ "$first_line" == '```'* ]]; then
+  echo "$response_text" | tail -n +2 | head -n -1 > "$output_typescript_file"
+else
+  echo "$response_text" > "$output_typescript_file"
+fi
 
 set +f

--- a/src/llm-providers.ts
+++ b/src/llm-providers.ts
@@ -1,0 +1,117 @@
+/**
+ * LLM provider configurations for the generate-workflow script.
+ *
+ * Supported providers:
+ * - Anthropic (Claude): set ANTHROPIC_API_KEY
+ * - MiniMax: set MINIMAX_API_KEY (uses OpenAI-compatible API)
+ */
+
+export interface LLMProviderConfig {
+  name: string;
+  apiUrl: string;
+  model: string;
+  /** Temperature value (MiniMax requires > 0.0, Anthropic accepts 0) */
+  temperature: number;
+  /** Returns auth headers for the provider */
+  authHeaders(apiKey: string): Record<string, string>;
+  /** Build the JSON request body for the given system and user prompts */
+  buildRequestBody(systemPrompt: string, userPrompt: string): object;
+  /** Extract the generated text from the API response */
+  parseResponse(response: unknown): string;
+}
+
+export const anthropicProvider: LLMProviderConfig = {
+  name: "anthropic",
+  apiUrl: "https://api.anthropic.com/v1/messages",
+  model: "claude-sonnet-4-20250514",
+  temperature: 0,
+  authHeaders(apiKey) {
+    return {
+      "x-api-key": apiKey,
+      "anthropic-version": "2023-06-01",
+    };
+  },
+  buildRequestBody(systemPrompt, userPrompt) {
+    return {
+      model: this.model,
+      system: systemPrompt,
+      max_tokens: 8192,
+      temperature: this.temperature,
+      messages: [{ role: "user", content: userPrompt }],
+    };
+  },
+  parseResponse(response) {
+    const r = response as { content?: Array<{ text?: string }> };
+    return r.content?.[0]?.text ?? "";
+  },
+};
+
+export const minimaxProvider: LLMProviderConfig = {
+  name: "minimax",
+  apiUrl: "https://api.minimax.io/v1/chat/completions",
+  model: "MiniMax-M2.7",
+  // MiniMax requires temperature in (0.0, 1.0] — use a near-zero value for deterministic output
+  temperature: 0.01,
+  authHeaders(apiKey) {
+    return { Authorization: `Bearer ${apiKey}` };
+  },
+  buildRequestBody(systemPrompt, userPrompt) {
+    return {
+      model: this.model,
+      messages: [
+        { role: "system", content: systemPrompt },
+        { role: "user", content: userPrompt },
+      ],
+      max_tokens: 8192,
+      temperature: this.temperature,
+    };
+  },
+  parseResponse(response) {
+    const r = response as {
+      choices?: Array<{ message?: { content?: string } }>;
+    };
+    return r.choices?.[0]?.message?.content ?? "";
+  },
+};
+
+/**
+ * Selects an LLM provider based on available environment variables.
+ * Prefers Anthropic when both keys are set.
+ *
+ * @param anthropicKey - value of ANTHROPIC_API_KEY (if set)
+ * @param minimaxKey   - value of MINIMAX_API_KEY (if set)
+ * @returns the selected provider config
+ * @throws if neither key is provided
+ */
+export function selectProvider(
+  anthropicKey?: string,
+  minimaxKey?: string
+): LLMProviderConfig {
+  if (anthropicKey) return anthropicProvider;
+  if (minimaxKey) return minimaxProvider;
+  throw new Error(
+    "Please set ANTHROPIC_API_KEY or MINIMAX_API_KEY environment variable"
+  );
+}
+
+/**
+ * Strip code-fence delimiters from a model response.
+ * Models may wrap generated TypeScript in ```typescript ... ``` blocks even
+ * when instructed not to; this removes those wrappers when present.
+ */
+export function stripCodeFences(text: string): string {
+  const lines = text.split("\n");
+  if (lines.length >= 2 && lines[0].startsWith("```")) {
+    // Drop the opening fence and, if the last non-empty line is a fence, it too
+    const inner = lines.slice(1);
+    const lastNonEmpty = inner.reduceRight(
+      (found, line, i) => (found === -1 && line.trim() !== "" ? i : found),
+      -1
+    );
+    if (lastNonEmpty !== -1 && inner[lastNonEmpty].startsWith("```")) {
+      inner.splice(lastNonEmpty, 1);
+    }
+    return inner.join("\n");
+  }
+  return text;
+}

--- a/test/llm-providers.spec.ts
+++ b/test/llm-providers.spec.ts
@@ -1,0 +1,167 @@
+import { expect, describe, it } from "vitest";
+import {
+  anthropicProvider,
+  minimaxProvider,
+  selectProvider,
+  stripCodeFences,
+} from "../src/llm-providers";
+
+describe("LLM Providers - Anthropic", () => {
+  it("should have the correct API URL", () => {
+    expect(anthropicProvider.apiUrl).toEqual(
+      "https://api.anthropic.com/v1/messages"
+    );
+  });
+
+  it("should return x-api-key and anthropic-version auth headers", () => {
+    const headers = anthropicProvider.authHeaders("sk-test");
+    expect(headers["x-api-key"]).toEqual("sk-test");
+    expect(headers["anthropic-version"]).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it("should build a request body with system as top-level field", () => {
+    const body = anthropicProvider.buildRequestBody(
+      "system instructions",
+      "user message"
+    ) as any;
+    expect(body.system).toEqual("system instructions");
+    expect(body.messages).toEqual([{ role: "user", content: "user message" }]);
+    expect(body.temperature).toEqual(0);
+    expect(body.max_tokens).toBeGreaterThan(0);
+  });
+
+  it("should parse content[0].text from Anthropic response format", () => {
+    const mockResponse = {
+      content: [{ type: "text", text: "import { z } from 'zod';" }],
+    };
+    expect(anthropicProvider.parseResponse(mockResponse)).toEqual(
+      "import { z } from 'zod';"
+    );
+  });
+
+  it("should return empty string when response has no content", () => {
+    expect(anthropicProvider.parseResponse({})).toEqual("");
+    expect(anthropicProvider.parseResponse({ content: [] })).toEqual("");
+  });
+});
+
+describe("LLM Providers - MiniMax", () => {
+  it("should use the OpenAI-compatible endpoint", () => {
+    expect(minimaxProvider.apiUrl).toEqual(
+      "https://api.minimax.io/v1/chat/completions"
+    );
+  });
+
+  it("should use MiniMax-M2.7 model", () => {
+    expect(minimaxProvider.model).toEqual("MiniMax-M2.7");
+  });
+
+  it("should return Bearer auth header", () => {
+    const headers = minimaxProvider.authHeaders("mm-key-abc");
+    expect(headers["Authorization"]).toEqual("Bearer mm-key-abc");
+    expect(Object.keys(headers)).not.toContain("x-api-key");
+    expect(Object.keys(headers)).not.toContain("anthropic-version");
+  });
+
+  it("should have temperature > 0 (MiniMax requires temperature in (0.0, 1.0])", () => {
+    expect(minimaxProvider.temperature).toBeGreaterThan(0);
+    expect(minimaxProvider.temperature).toBeLessThanOrEqual(1);
+  });
+
+  it("should build a request body with system as first message in messages array", () => {
+    const body = minimaxProvider.buildRequestBody(
+      "system instructions",
+      "user message"
+    ) as any;
+    expect(body.messages).toHaveLength(2);
+    expect(body.messages[0]).toEqual({
+      role: "system",
+      content: "system instructions",
+    });
+    expect(body.messages[1]).toEqual({
+      role: "user",
+      content: "user message",
+    });
+    expect(body.system).toBeUndefined();
+  });
+
+  it("should parse choices[0].message.content from OpenAI-compatible response format", () => {
+    const mockResponse = {
+      choices: [
+        {
+          message: { role: "assistant", content: "import { z } from 'zod';" },
+          finish_reason: "stop",
+        },
+      ],
+    };
+    expect(minimaxProvider.parseResponse(mockResponse)).toEqual(
+      "import { z } from 'zod';"
+    );
+  });
+
+  it("should return empty string when response has no choices", () => {
+    expect(minimaxProvider.parseResponse({})).toEqual("");
+    expect(minimaxProvider.parseResponse({ choices: [] })).toEqual("");
+  });
+});
+
+describe("selectProvider", () => {
+  it("should return anthropicProvider when ANTHROPIC_API_KEY is set", () => {
+    const provider = selectProvider("sk-ant-key", undefined);
+    expect(provider.name).toEqual("anthropic");
+  });
+
+  it("should return minimaxProvider when only MINIMAX_API_KEY is set", () => {
+    const provider = selectProvider(undefined, "mm-key");
+    expect(provider.name).toEqual("minimax");
+  });
+
+  it("should prefer anthropic when both keys are set", () => {
+    const provider = selectProvider("sk-ant-key", "mm-key");
+    expect(provider.name).toEqual("anthropic");
+  });
+
+  it("should throw when neither key is set", () => {
+    expect(() => selectProvider(undefined, undefined)).toThrow(
+      /ANTHROPIC_API_KEY|MINIMAX_API_KEY/
+    );
+  });
+
+  it("should throw when both keys are empty strings", () => {
+    expect(() => selectProvider("", "")).toThrow();
+  });
+});
+
+describe("stripCodeFences", () => {
+  it("should remove ```typescript fences", () => {
+    const input = "```typescript\nimport foo from 'foo';\n```";
+    const result = stripCodeFences(input);
+    expect(result).toEqual("import foo from 'foo';");
+  });
+
+  it("should remove plain ``` fences", () => {
+    const input = "```\nconst x = 1;\n```";
+    const result = stripCodeFences(input);
+    expect(result).toEqual("const x = 1;");
+  });
+
+  it("should return text unchanged when there are no code fences", () => {
+    const input = "import { z } from 'zod';\nconst x = z.string();";
+    expect(stripCodeFences(input)).toEqual(input);
+  });
+
+  it("should preserve multi-line code", () => {
+    const input =
+      "```typescript\nline1\nline2\nline3\n```";
+    const result = stripCodeFences(input);
+    expect(result).toEqual("line1\nline2\nline3");
+  });
+
+  it("should handle text with only an opening fence gracefully", () => {
+    const input = "```typescript\nconst x = 1;";
+    const result = stripCodeFences(input);
+    // Opening fence stripped but no closing fence found — inner content preserved
+    expect(result).toContain("const x = 1;");
+    expect(result).not.toContain("```typescript");
+  });
+});


### PR DESCRIPTION
## Summary

The `generate-workflow` script previously required an Anthropic API key. This PR adds **MiniMax** as a drop-in alternative, using the [MiniMax OpenAI-compatible API](https://api.minimax.io/v1) and the `MiniMax-M2.7` model (204 K context).

**Provider selection** is automatic — no config file changes needed:
- `ANTHROPIC_API_KEY` → Anthropic Claude (existing behaviour, unchanged)
- `MINIMAX_API_KEY` → MiniMax M2.7 (new)

When both keys are set, Anthropic is preferred.

## Changes

| File | What changed |
|---|---|
| `generate-workflow` | Added MiniMax branch (OpenAI-compat format, `temperature: 0.01` to satisfy `(0, 1]` constraint); smarter code-fence stripping |
| `src/llm-providers.ts` | New typed module — provider configs, `selectProvider()`, `stripCodeFences()` |
| `test/llm-providers.spec.ts` | 22 unit tests (both providers, selection logic, fence stripping) |
| `DEVELOPING.md` | Updated docs: provider table with env var + model info |

## Test plan

- [x] `npm run unit-test` — all 47 existing tests pass
- [x] `npx vitest run test/llm-providers.spec.ts` — all 22 new tests pass
- [ ] Manual: set `MINIMAX_API_KEY` and run `./generate-workflow <workflow.json> out.ts` to verify end-to-end code generation
- [ ] Manual: verify `ANTHROPIC_API_KEY` path is unchanged